### PR TITLE
Fix align_center for multiline text with tight width

### DIFF
--- a/lib/strings/align.rb
+++ b/lib/strings/align.rb
@@ -89,7 +89,7 @@ module Strings
           left_count  =  width_diff - right_count
           [fill * left_count, line, fill * right_count].join
         else
-          text
+          line
         end
       end
     end

--- a/spec/unit/align/align_spec.rb
+++ b/spec/unit/align/align_spec.rb
@@ -30,10 +30,18 @@ RSpec.describe Strings::Align, '#align' do
   it "centers multiline text" do
     text = "for there is no folly of the beast\nof the earth which\nis not infinitely\noutdone by the madness of men"
     expect(Strings::Align.align_center(text, 40)).to eq([
-     "   for there is no folly of the beast   \n",
-     "           of the earth which           \n",
-     "           is not infinitely            \n",
-     "     outdone by the madness of men      "
+      "   for there is no folly of the beast   \n",
+      "           of the earth which           \n",
+      "           is not infinitely            \n",
+      "     outdone by the madness of men      "
+    ].join)
+  end
+
+  it "centers multiline text with exact width" do
+    text = "the madness \nof men"
+    expect(Strings::Align.align_center(text, 12)).to eq([
+      "the madness \n",
+      "   of men   "
     ].join)
   end
 
@@ -50,20 +58,20 @@ RSpec.describe Strings::Align, '#align' do
   it "centers text with ansi codes" do
     text = "for \e[35mthere\e[0m is no folly of the beast\nof the \e[33mearth\e0m which\nis \e[34mnot infinitely\e[0m\n\e[33moutdone\e[0m by the madness of men"
     expect(Strings::Align.align_center(text, 40)).to eq([
-     "   for \e[35mthere\e[0m is no folly of the beast   \n",
-     "           of the \e[33mearth\e0m which           \n",
-     "           is \e[34mnot infinitely\e[0m            \n",
-     "     \e[33moutdone\e[0m by the madness of men      "
+      "   for \e[35mthere\e[0m is no folly of the beast   \n",
+      "           of the \e[33mearth\e0m which           \n",
+      "           is \e[34mnot infinitely\e[0m            \n",
+      "     \e[33moutdone\e[0m by the madness of men      "
     ].join)
   end
 
   it "centers multiline text with fill character '*'" do
     text = "for there is no folly of the beast\nof the earth which\nis not infinitely\noutdone by the madness of men"
     expect(Strings::Align.align(text, 40, direction: :center, fill: '*')).to eq([
-     "***for there is no folly of the beast***\n",
-     "***********of the earth which***********\n",
-     "***********is not infinitely************\n",
-     "*****outdone by the madness of men******"
+      "***for there is no folly of the beast***\n",
+      "***********of the earth which***********\n",
+      "***********is not infinitely************\n",
+      "*****outdone by the madness of men******"
     ].join)
   end
 end


### PR DESCRIPTION
This PR fixes `#align_center` in cases where the text is a multi-line string, and the requested width is exactly or lower than the longest line in the string.

This code:

```ruby
text = "Drawing some \ntext"
puts Strings.align(text, 13, direction: :center)
```

Created this output before the PR:

```
Drawing some
text
    text
```

And it now - correctly - creates this output:

```
Drawing some
    text
```

This was discovered in https://github.com/piotrmurach/tty-box/issues/2

In addition, I have added a test case for it, and normalized the indentation in the `align_spec.rb` file - it sometimes had two spaces, sometimes one.

Specs are passing locally, and failing without the fix.


