### PR TITLE
Fix typo in YARD parameter name annotation

### DIFF
--- a/lib/strings/padder.rb
+++ b/lib/strings/padder.rb
@@ -72,7 +72,7 @@ module Strings
 
     # Set top padding
     #
-    # @param [Integer] val
+    # @param [Integer] value
     #
     # @return [nil]
     #
@@ -92,7 +92,7 @@ module Strings
 
     # Set right padding
     #
-    # @param [Integer] val
+    # @param [Integer] value
     #
     # @api public
     def right=(value)


### PR DESCRIPTION
### Description

This avoids YARD docstring warnings by indicating the right spelling of the parameter to document.

### Why are we doing this?

Correct docs, no warnings.

### Benefits

One less warning at installation, for users who use YARD.

### Drawbacks
Possible drawbacks applying this change.

