### PR TITLE
CI: 2.4.6, 2.5.5, 2.6.2, jruby-9.2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
 language: ruby
-sudo: false
 before_install: "gem install bundler -v '< 2.0'"
 script: "bundle exec rake ci"
 rvm:
@@ -8,17 +7,17 @@ rvm:
   - 2.1.10
   - 2.2.10
   - 2.3.8
-  - 2.4.5
-  - 2.5.3
-  - 2.6.1
+  - 2.4.6
+  - 2.5.5
+  - 2.6.2
   - ruby-head
-  - jruby-9.1.5.0
+  - jruby-9.2.6.0
   - jruby-head
 matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
-    - rvm: jruby-9.1.5.0
+    - rvm: jruby-9.2.6.0
   fast_finish: true
 branches:
   only: master


### PR DESCRIPTION
### Description

Updates the CI matrix

Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

### Why are we doing this?

Check against latest.

### Benefits

We will know that it still works as intended.

### Drawbacks

...

