### PR TITLE
Replace old reference to `verse`

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/piotrmurach/strings. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
-1. Fork it ( https://github.com/piotrmurach/verse/fork )
+1. Fork it ( https://github.com/piotrmurach/strings/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)


### PR DESCRIPTION
Here’s one reference to `verse` which should likely be `strings` instead!