### PR TITLE
Fix Strings.truncate with length '1'

### DIFF
--- a/lib/strings/truncate.rb
+++ b/lib/strings/truncate.rb
@@ -70,6 +70,7 @@ module Strings
     # @api private
     def shorten(original_chars, chars, length_without_trailing)
       truncated = []
+      return truncated if length_without_trailing.zero?
       char_width = display_width(chars[0])
       while length_without_trailing - char_width > 0
         orig_char = original_chars.shift

--- a/spec/unit/truncate/truncate_spec.rb
+++ b/spec/unit/truncate/truncate_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Strings::Truncate, '#truncate' do
     expect(Strings::Truncate.truncate(text, nil)).to eq(text)
   end
 
+  it "truncate length of 1 results in just the trailing character" do
+    expect(Strings::Truncate.truncate(text, 1)).to eq(Strings::Truncate::DEFAULT_TRAILING)
+  end
+
   it "doesn't change text for equal length" do
     truncation = Strings::Truncate.truncate(text, text.length * 2)
     expect(truncation).to eq(text)


### PR DESCRIPTION
### Describe the change
Fixes an issue where passing a truncate value of 1 results in an unhandled exception.

```
[2] pry(main)> Strings.truncate('data', 1)
NoMethodError: undefined method `gsub' for nil:NilClass
from /usr/home/kschiesser/.rvm/gems/ruby-2.6.3/gems/strings-ansi-0.1.0/lib/strings/ansi.rb:29:in `sanitize'
[3] pry(main)> wtf
Exception: NoMethodError: undefined method `gsub' for nil:NilClass
--
0: /usr/home/kschiesser/.rvm/gems/ruby-2.6.3/gems/strings-ansi-0.1.0/lib/strings/ansi.rb:29:in `sanitize'
1: /usr/home/kschiesser/code/strings/lib/strings/truncate.rb:103:in `display_width'
2: /usr/home/kschiesser/code/strings/lib/strings/truncate.rb:74:in `shorten'
3: /usr/home/kschiesser/code/strings/lib/strings/truncate.rb:62:in `truncate'
4: /usr/home/kschiesser/code/strings/lib/strings.rb:99:in `truncate'
```

vs

```
[2] pry(main)> Strings.truncate('data', 1)
=> "\u2026"
```

### Why are we doing this?
Unhandled exceptions are generally bad :)
Related to piotrmurach/tty-table#20

### Benefits
Better handling for all cases on Strings::Truncate

### Drawbacks
None that I can see.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
