### PR TITLE
Remove warnings caused by ruby 2.7 keyword args checks.

### DIFF
--- a/lib/strings.rb
+++ b/lib/strings.rb
@@ -15,8 +15,8 @@ module Strings
   # @see Strings::Align#align
   #
   # @api public
-  def align(*args)
-    Align.align(*args)
+  def align(*args, **kws)
+    Align.align(*args, **kws)
   end
   module_function :align
 

--- a/lib/strings/align.rb
+++ b/lib/strings/align.rb
@@ -39,7 +39,7 @@ module Strings
     def align(text, width, direction: :left, **options)
       return text if width.nil?
       method = to_alignment(direction)
-      send(method, text, width, options)
+      send(method, text, width, **options)
     end
     module_function :align
 

--- a/lib/strings/extensions.rb
+++ b/lib/strings/extensions.rb
@@ -5,8 +5,8 @@ require_relative '../strings'
 module Strings
   module Extensions
     refine String do
-      def align(*args)
-        Align.align(self, *args)
+      def align(*args, **kws)
+        Align.align(self, *args, **kws)
       end
 
       def align_left(*args)


### PR DESCRIPTION
Signed-off-by: Ryan Davis <zenspider@chef.io>