### PR TITLE
Update code examples in comments

### DIFF
--- a/lib/strings/align.rb
+++ b/lib/strings/align.rb
@@ -23,16 +23,16 @@ module Strings
     # @example
     #   text = "the madness of men"
     #
-    #   Strings::Align.align(22, :left)
+    #   Strings::Align.align(text, 22, direction: :left)
     #   # => "the madness of men      "
     #
-    #   Strings::Align.align(22, :center)
+    #   Strings::Align.align(text, 22, direction: :center)
     #   # => "   the madness of men   "
     #
-    #   Strings::Align(22, :right)
+    #   Strings::Align(text, 22, direction: :right)
     #   # => "      the madness of men"
     #
-    #   Strings::Align.align(22, :center, fill: '*)
+    #   Strings::Align.align(text, 22, direction: :center, fill: '*')
     #   # => "***the madness of men***"
     #
     # @api public

--- a/lib/strings/fold.rb
+++ b/lib/strings/fold.rb
@@ -7,7 +7,7 @@ module Strings
     # Fold a multiline text into a single line string
     #
     # @example
-    #   fold("\tfoo \r\n\n bar") # => "foo  bar"
+    #   fold("\tfoo \r\n\n bar") # => " foo  bar"
     #
     # @param [String] text
     #

--- a/lib/strings/truncate.rb
+++ b/lib/strings/truncate.rb
@@ -27,15 +27,15 @@ module Strings
     #   text = "The sovereignest thing on earth is parmacetti for an inward bruise."
     #
     #   Strings::Truncate.truncate(text)
-    #   # => "The sovereignest thing on ear…"
+    #   # => "The sovereignest thing on ea…"
     #
     #   Strings::Truncate.truncate(text, 20)
-    #   # => "The sovereignest th…"
+    #   # => "The sovereignest t…"
     #
     #   Strings::Truncate.truncate(text, 20, separator: ' ' )
     #   # => "The sovereignest…"
     #
-    #   Strings::Truncate.truncate(40, trailing: '... (see more)' )
+    #   Strings::Truncate.truncate(text, 40, trailing: '... (see more)' )
     #   # => "The sovereignest thing on... (see more)"
     #
     # @api public

--- a/lib/strings/wrap.rb
+++ b/lib/strings/wrap.rb
@@ -19,9 +19,7 @@ module Strings
     #
     # @example
     #   Strings::Wrap.wrap("Some longish text", 8)
-    #   # => >Some
-    #        >longish
-    #        >text
+    #   # => "Some \nlongish \ntext"
     #
     # @api public
     def wrap(text, wrap_at = DEFAULT_WIDTH, separator: nil)


### PR DESCRIPTION
Fix code examples in comments that have missing arguments
and/or wrong return value.