### PR TITLE
Fix docs relating to specifying separator in truncate method (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Strings::Truncate.truncate(text, 20) # => "for there is no fol…"
 If you want to split words on their boundaries use `:separator` option:
 
 ```ruby
-Strings.truncate(text, 20) # => "for there is no…"
+Strings.truncate(text, 20, separator: ' ') # => "for there is no…"
 ```
 
 Use `:trailing` option (by default `…`) to provide omission characters:


### PR DESCRIPTION
Fixes the docs relating to specifying separator in truncate method, as mentioned in issue #13.

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentaion updated?
