### PR TITLE
Fix Strings.truncate to return the correct length

### DIFF
--- a/lib/strings/truncate.rb
+++ b/lib/strings/truncate.rb
@@ -77,15 +77,22 @@ module Strings
         char = chars.shift
         break unless char
         while orig_char != char # consume ansi
-          ansi = true
-          truncated << orig_char
+          next_four_chars = orig_char + original_chars[0..2].join
+          if next_four_chars == Strings::ANSI::RESET
+            ansi = false
+            truncated << [Strings::ANSI::RESET]
+            original_chars.shift(3) # Skip rest of ANSI reset code
+          else
+            ansi = true
+            truncated << orig_char
+          end
           orig_char = original_chars.shift
         end
         truncated << char
         char_width = display_width(char)
         length_without_trailing -= char_width
       end
-      truncated << ["\e[0m"] if ansi
+      truncated << [Strings::ANSI::RESET] if ansi
       truncated
     end
     module_function :shorten

--- a/lib/strings/truncate.rb
+++ b/lib/strings/truncate.rb
@@ -11,7 +11,7 @@ module Strings
 
     DEFAULT_LENGTH = 30
 
-    # Truncate a text at a given length (defualts to 30)
+    # Truncate a text at a given length (defaults to 30)
     #
     # @param [String] text
     #   the text to be truncated
@@ -72,7 +72,7 @@ module Strings
       truncated = []
       return truncated if length_without_trailing.zero?
       char_width = display_width(chars[0])
-      while length_without_trailing - char_width > 0
+      while length_without_trailing - char_width >= 0
         orig_char = original_chars.shift
         char = chars.shift
         break unless char

--- a/spec/unit/extensions_spec.rb
+++ b/spec/unit/extensions_spec.rb
@@ -57,12 +57,12 @@ RSpec.describe Strings::Extensions do
 
   it "truncates a line" do
     text = "the madness of men"
-    expect(text.truncate(10)).to eq("the madn…")
+    expect(text.truncate(10)).to eq("the madne…")
   end
 
   it "truncates a line with a custom trailing" do
     text = "the madness of men"
-    expect(text.truncate(10, trailing: "...")).to eq("the ma...")
+    expect(text.truncate(10, trailing: "...")).to eq("the mad...")
   end
 
   it "truncates into words with a custom trailing" do

--- a/spec/unit/truncate/truncate_spec.rb
+++ b/spec/unit/truncate/truncate_spec.rb
@@ -63,7 +63,13 @@ RSpec.describe Strings::Truncate, "#truncate" do
   it "correctly truncates with ANSI characters" do
     text = "I try \e[34mall things\e[0m, I achieve what I can"
     truncation = Strings::Truncate.truncate(text, 18)
-    expect(truncation).to eq("I try \e[34mall things\e[0m,\e[0m…")
+    expect(truncation).to eq("I try \e[34mall things\e[0m,…")
+  end
+
+  it "correctly truncates with multiple ANSI character usages" do
+    text = "I try \e[34mall things\e[0m, I \e[32machieve\e[0m what I can"
+    truncation = Strings::Truncate.truncate(text, 29)
+    expect(truncation).to eq("I try \e[34mall things\e[0m, I \e[32machieve\e[0m …")
   end
 
   it "finishes on word boundary" do
@@ -74,8 +80,13 @@ RSpec.describe Strings::Truncate, "#truncate" do
 
   it "returns the correct number of characters" do
     text = "I try all things, I achieve what I can"
-    trunc_length = 14
-    truncated_text = Strings::Truncate.truncate(text, trunc_length)
-    expect(truncated_text.length).to eq(trunc_length)
+    truncated_text = Strings::Truncate.truncate(text, 14)
+    expect(truncated_text.length).to eq(14)
+  end
+
+  it "returns the correct number of wide-characters" do
+    text = "真剣だど、知恵が出る"
+    truncated_text = Strings::Truncate.truncate(text, 14)
+    expect(truncated_text.length).to be(7)
   end
 end

--- a/spec/unit/truncate/truncate_spec.rb
+++ b/spec/unit/truncate/truncate_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Strings::Truncate, "#truncate" do
     expect(Strings::Truncate.truncate(text, 0)).to eq(text)
   end
 
-  it "doensn't change text for nil length" do
+  it "doesn't change text for nil length" do
     expect(Strings::Truncate.truncate(text, nil)).to eq(text)
   end
 
@@ -57,18 +57,25 @@ RSpec.describe Strings::Truncate, "#truncate" do
   it "truncates text with custom trailing" do
     trailing = "... (see more)"
     truncation = Strings::Truncate.truncate(text, 20, trailing: trailing)
-    expect(truncation).to eq("ラド#{trailing}")
+    expect(truncation).to eq("ラドク#{trailing}")
   end
 
   it "correctly truncates with ANSI characters" do
     text = "I try \e[34mall things\e[0m, I achieve what I can"
     truncation = Strings::Truncate.truncate(text, 18)
-    expect(truncation).to eq("I try \e[34mall things\e[0m…")
+    expect(truncation).to eq("I try \e[34mall things\e[0m,\e[0m…")
   end
 
   it "finishes on word boundary" do
     text = "for there is no folly of the beast of the earth"
     truncation = Strings::Truncate.truncate(text, 20, separator: " ")
     expect(truncation).to eq("for there is no…")
+  end
+
+  it "returns the correct number of characters" do
+    text = "I try all things, I achieve what I can"
+    trunc_length = 14
+    truncated_text = Strings::Truncate.truncate(text, trunc_length)
+    expect(truncated_text.length).to eq(trunc_length)
   end
 end


### PR DESCRIPTION
### Describe the change
Fixes https://github.com/piotrmurach/strings/issues/17

### Why are we doing this?
I believe we should be returning characters of N display width when specifying `Strings.truncate(s, N)`.

### Benefits
`Strings.truncate` will be more intuitive (e.g. follow the [Principle of Least Surprise](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)).

### Drawbacks
It is possible that existing usages of this library are coded to expect the width of displayed characters to be strictly < `truncate_at`, but equal to it. In this case, they will get potentially an extra character.

If this is a concern, we could instead update the documentation [here](https://github.com/piotrmurach/strings#26-truncate) to specifying that `truncate_at` is not inclusive (e.g. `Strings.truncate` does not return a character at `truncate_at` width).

Alternatively, we could introduce an `:inclusive` option (defaulted to `false`) which would treat the behavior of `truncate_at` as inclusive when passed. 

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[] Code style checked?
[X] Rebased with `master` branch?
[] Documentation updated?
