### PR TITLE
Update README with new info on Truncate status

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ Strings::ANSI.sanitize("\e[33;44mfoo\e[0m")
 
 ### 2.6 truncate
 
+Please note this API will change in the next release and will be replaced by the `strings-truncation` component. See the [Components](#4-components) section for more information.
+
 You can truncate a given text after a given length with `truncate` method.
 
 Given the following text:


### PR DESCRIPTION
Truncation functionality has been extracted into the component gem [strings-truncation](https://github.com/piotrmurach/strings-truncation).

### Describe the change
Updates the README with a bit of clarification.

### Why are we doing this?
To communicate where people should go for ANSI-friendly truncate functionality.

### Benefits
Improved docs

### Drawbacks
None

### Requirements
Put an X between brackets on each line if you have done the item:
[X] Tests written & passing locally?
[X] Code style checked?
[X] Rebased with `master` branch?
[X] Documentaion updated?
