### PR TITLE
Fix IndexError in `Strings::Wrap.wrap` and correct ANSI color insertion on wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Unreleased
+
+### Fixed
+
+* Fix IndexError in `Strings::Wrap.wrap` and correct ANSI color insertion on wrap (@onk)
+
 ## [v0.2.1] - 2021-03-09
 
 ### Changed

--- a/lib/strings/wrap.rb
+++ b/lib/strings/wrap.rb
@@ -146,7 +146,7 @@ module Strings
           next
         elsif !matched_reset # ansi without reset
           matched_reset = false
-          new_stack << ansi # keep the ansi
+          new_stack.unshift([ansi[0], 0]) # carry over ANSI to the start of next line preserving order
           next if ansi[1] == length
           if output.end_with?(NEWLINE)
             output.insert(-2, ansi_reset)

--- a/spec/unit/wrap/insert_ansi_spec.rb
+++ b/spec/unit/wrap/insert_ansi_spec.rb
@@ -60,6 +60,6 @@ RSpec.describe "#insert_ansi" do
     val = Strings::Wrap.insert_ansi(text, stack)
 
     expect(val).to eq("\e[32mone\e[0m")
-    expect(stack).to eq([["\e[33m", 3]])
+    expect(stack).to eq([["\e[33m", 0]])
   end
 end

--- a/spec/unit/wrap/wrap_spec.rb
+++ b/spec/unit/wrap/wrap_spec.rb
@@ -186,6 +186,15 @@ RSpec.describe Strings::Wrap, ".wrap" do
       ].join("\n"))
     end
 
+    it "applies stacked ANSI colors after wrapping" do
+      text = "aaaa \e[31mbbbb \e[32mcc"
+      expect(Strings::Wrap.wrap(text, 5)).to eq([
+        "aaaa ",
+        "\e[31mbbbb \e[0m",
+        "\e[31m\e[32mcc\e[0m\e[0m"
+      ].join("\n"))
+    end
+
     it "applies ANSI codes when below wrap width" do
       str = "\e[32mone\e[0m\e[33mtwo\e[0m"
 

--- a/spec/unit/wrap/wrap_spec.rb
+++ b/spec/unit/wrap/wrap_spec.rb
@@ -178,6 +178,14 @@ RSpec.describe Strings::Wrap, ".wrap" do
       ].join("\n"))
     end
 
+    it "wraps when ANSI start carries over to the next line" do
+      text = "aaaaaaa \e[31mbb"
+      expect(Strings::Wrap.wrap(text, 8)).to eq([
+        "aaaaaaa ",
+        "\e[31mbb\e[0m"
+      ].join("\n"))
+    end
+
     it "applies ANSI codes when below wrap width" do
       str = "\e[32mone\e[0m\e[33mtwo\e[0m"
 


### PR DESCRIPTION
### Describe the change

When wrapping lines, reset the insertion index of carried-over ANSI codes to 0 so that they are always applied at the start of the new line.

This probably fixes #4 and #16.

### Why are we doing this?

#### 1. Prevent IndexError

When an ANSI code appeared at the end of a line, and the wrapped remainder of the text was shorter, the code was reinserted at an out-of-range position on the next line, causing an IndexError. Resetting the insertion position resolves this issue.

Repro:

```ruby
Strings::Wrap.wrap("aaaaaaa \e[31mbb", 8)
# /Users/.../strings/wrap.rb:158:in `String#insert': index 8 out of string (IndexError)
#   from ... Strings::Wrap.wrap
```

#### 2. Preserve ANSI stack when reapplying colors

`insert_ansi` kept using the original insert index from the previous line, so carry-over codes without resets were reinserted at the wrong position.
Resetting every pending entry to `[code, 0]` to be applied at the line start, which prevents misplaced inserts and lets nested codes line up correctly.

Repro:

```ruby
Strings::Wrap.wrap("aaaa \e[31mbbbb \e[32mcc", 5)
```

Expected:

```
aaaa 
\e[31mbbbb \e[0m
\e[31m\e[32mcc\e[0m\e[0m
```

Actual:

```
aaaa 
bbbb 
cc\e[0\e[32m\e[31mm\e[0m
```

### Benefits

- Prevents `IndexError` caused by reinserting ANSI codes past string boundaries
- Ensures ANSI color state is reapplied consistently across wrapped lines

### Drawbacks

### Requirements
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
