### PR TITLE
Track unclosed ANSI sequences to preserve correct color state across wraps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Unreleased
+
+### Fixed
+
+* Fix IndexError in `Strings::Wrap.wrap` and correct ANSI color insertion on wrap (@onk)
+
 ## [v0.2.1] - 2021-03-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 * Fix IndexError in `Strings::Wrap.wrap` and correct ANSI color insertion on wrap (@onk)
+* Track unclosed ANSI sequences to preserve correct color state across wraps (@onk)
 
 ## [v0.2.1] - 2021-03-09
 

--- a/lib/strings/wrap.rb
+++ b/lib/strings/wrap.rb
@@ -146,7 +146,7 @@ module Strings
           next
         elsif !matched_reset # ansi without reset
           matched_reset = false
-          new_stack << ansi # keep the ansi
+          new_stack.unshift([ansi[0], 0]) # carry over ANSI to the start of next line preserving order
           next if ansi[1] == length
           if output.end_with?(NEWLINE)
             output.insert(-2, ansi_reset)

--- a/lib/strings/wrap.rb
+++ b/lib/strings/wrap.rb
@@ -135,17 +135,16 @@ module Strings
       new_stack = []
       output          = string.dup
       length          = string.size
-      matched_reset   = false
+      pending_resets  = 0
       ansi_reset      = Strings::ANSI::RESET
 
       # Reversed so that string index don't count ansi
       ansi_stack.reverse_each do |ansi|
         if ansi[0] =~ /#{Regexp.quote(ansi_reset)}/
-          matched_reset = true
+          pending_resets += 1
           output.insert(ansi[1], ansi_reset)
           next
-        elsif !matched_reset # ansi without reset
-          matched_reset = false
+        elsif pending_resets.zero? # ansi without reset
           new_stack.unshift([ansi[0], 0]) # carry over ANSI to the start of next line preserving order
           next if ansi[1] == length
           if output.end_with?(NEWLINE)
@@ -153,6 +152,8 @@ module Strings
           else
             output.insert(-1, ansi_reset) # add reset at the end
           end
+        else
+          pending_resets -= 1
         end
 
         output.insert(ansi[1], ansi[0])

--- a/spec/unit/wrap/insert_ansi_spec.rb
+++ b/spec/unit/wrap/insert_ansi_spec.rb
@@ -60,6 +60,6 @@ RSpec.describe "#insert_ansi" do
     val = Strings::Wrap.insert_ansi(text, stack)
 
     expect(val).to eq("\e[32mone\e[0m")
-    expect(stack).to eq([["\e[33m", 3]])
+    expect(stack).to eq([["\e[33m", 0]])
   end
 end

--- a/spec/unit/wrap/wrap_spec.rb
+++ b/spec/unit/wrap/wrap_spec.rb
@@ -186,6 +186,15 @@ RSpec.describe Strings::Wrap, ".wrap" do
       ].join("\n"))
     end
 
+    it "applies stacked ANSI colors after wrapping" do
+      text = "aaaa \e[31mbbbb \e[32mcc"
+      expect(Strings::Wrap.wrap(text, 5)).to eq([
+        "aaaa ",
+        "\e[31mbbbb \e[0m",
+        "\e[31m\e[32mcc\e[0m\e[0m"
+      ].join("\n"))
+    end
+
     it "applies ANSI codes when below wrap width" do
       str = "\e[32mone\e[0m\e[33mtwo\e[0m"
 

--- a/spec/unit/wrap/wrap_spec.rb
+++ b/spec/unit/wrap/wrap_spec.rb
@@ -178,6 +178,14 @@ RSpec.describe Strings::Wrap, ".wrap" do
       ].join("\n"))
     end
 
+    it "wraps when ANSI start carries over to the next line" do
+      text = "aaaaaaa \e[31mbb"
+      expect(Strings::Wrap.wrap(text, 8)).to eq([
+        "aaaaaaa ",
+        "\e[31mbb\e[0m"
+      ].join("\n"))
+    end
+
     it "applies ANSI codes when below wrap width" do
       str = "\e[32mone\e[0m\e[33mtwo\e[0m"
 

--- a/spec/unit/wrap/wrap_spec.rb
+++ b/spec/unit/wrap/wrap_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe Strings::Wrap, ".wrap" do
       expect(val).to eq("\e[32mone\e[0m\n\e[33mtwo\e[0m")
     end
 
-    xit "splits ANSI codes matching wrap width" do
+    it "splits ANSI codes matching wrap width" do
       str = "\e[32mone\e[0m\e[33mtwo\e[0m"
 
       val = Strings::Wrap.wrap(str, 3)
@@ -219,14 +219,14 @@ RSpec.describe Strings::Wrap, ".wrap" do
       expect(val).to eq("\e[32mone\e[0m\n\e[33mtwo\e[0m")
     end
 
-    xit "wraps deeply nested ANSI codes correctly" do
+    it "wraps deeply nested ANSI codes correctly" do
       str = "\e[32mone\e[33mtwo\e[0m\e[0m"
 
       val = Strings::Wrap.wrap(str, 3)
 
       expect(val).to eq([
         "\e[32mone\e[0m",
-        "\e[33mtwo\e[0m",
+        "\e[32m\e[33mtwo\e[0m\e[0m",
       ].join("\n"))
     end
   end


### PR DESCRIPTION
Please review after #23.

### Describe the change

The wrapping logic now tracks the count of unclosed ANSI sequences rather than using a boolean flag.
This allows multiple or nested ANSI codes to be preserved correctly when text is wrapped across lines.

### Why are we doing this?

### Benefits

### Drawbacks

### Requirements

- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
